### PR TITLE
Enable optional access by default in expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@types/estree": "^0.0.48",
-    "acorn": "^7.2.0"
+    "@types/estree": "^0.0.52",
+    "acorn": "^8.7.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,7 +126,7 @@ interface ExpressionHandler<R, C> {
     params: ExpressionHandleParams<ConditionalExpression, R, C>
   ): R;
   onMemberExpression(params: ExpressionHandleParams<MemberExpression, R, C>): R;
-  onCallExpression(params: ExpressionHandleParams<CallExpression, R, C>): R;
+  onCallExpression(params: ExpressionHandleParams<SimpleCallExpression, R, C>): R;
   onTemplateLiteral(params: ExpressionHandleParams<TemplateLiteral, R, C>): R;
   onIdentifier(params: ExpressionHandleParams<Identifier, R, C>): R;
   onLiteral(params: ExpressionHandleParams<Literal, R, C>): R;
@@ -587,10 +587,10 @@ const expressionEvaluator: ExpressionHandler<any, EvaluationContext> = {
       assertSupportedExpression(callee.object);
       const object = callback(callee.object, context);
       const call = callback(callee, context);
-      return call.apply(object, args);
+      return call?.apply(object, args);
     } else {
       const call = callback(callee, context);
-      return call.apply(context, args);
+      return call?.apply(context, args);
     }
   },
 
@@ -602,7 +602,6 @@ const expressionEvaluator: ExpressionHandler<any, EvaluationContext> = {
       expression.property,
       expression.computed ? context : { ...context, member: true }
     );
-    const ret = object[property];
     // disallow prototype / constructor access
     if (
       property === "prototype" ||
@@ -611,6 +610,7 @@ const expressionEvaluator: ExpressionHandler<any, EvaluationContext> = {
     ) {
       return undefined;
     }
+    const ret = object?.[property];
     return ret;
   },
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -94,25 +94,40 @@ describe("esformula", () => {
     assert.ok(formula != null);
     assert.deepEqual(formula.identifiers.sort(), ["a", "b"].sort());
     assert.ok(formula.evaluate({ a: { foo: 1 }, b: "foo" }) === 1);
+    // property access works as optional chaining is enabled
+    assert.ok(formula.evaluate({ b: "foo" }) === undefined);
 
     formula = parse("a.b");
     assert.ok(formula != null);
     assert.deepEqual(formula.identifiers, ["a"]);
     assert.ok(formula.evaluate({ a: { b: 1 } }) === 1);
+    // property access works as optional chaining is enabled
+    assert.ok(formula.evaluate({}) === undefined);
 
     formula = parse('a.b["c"]');
     assert.ok(formula != null);
     assert.deepEqual(formula.identifiers.sort(), ["a"]);
     assert.ok(formula.evaluate({ a: { b: { c: 1 } } }) === 1);
+    // property access works as optional chaining is enabled
+    assert.ok(formula.evaluate({ a: {} }) === undefined);
   });
 
   test("call expression", () => {
-    const formula = parse("a(b)");
+    let formula = parse("a(b)");
     assert.ok(formula != null);
     assert.deepEqual(formula.identifiers.sort(), ["a", "b"].sort());
     const a = (x: any) => x * x;
     const b = 2;
     assert.ok(formula.evaluate({ a, b }) === a(b));
+    // works as optional chaining is enabled
+    assert.ok(formula.evaluate({ b }) === undefined);
+
+    formula = parse("b.a(2)");
+    assert.ok(formula != null);
+    assert.deepEqual(formula.identifiers, ["b"]);
+    assert.ok(formula.evaluate({ b: { a } }) === a(2));
+    // works as optional chaining is enabled
+    assert.ok(formula.evaluate({}) === undefined);
   });
 
   test("method call expression", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1499,10 +1499,10 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
-"@types/estree@^0.0.48":
-  version "0.0.48"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.48.tgz#18dc8091b285df90db2f25aa7d906cfc394b7f74"
-  integrity sha512-LfZwXoGUDo0C3me81HXgkBg5CTQYb6xzEl+fNmbO4JdRiSKQ8A0GD1OBBvKAIsbCUgoyAty7m99GqqMQe784ew==
+"@types/estree@^0.0.52":
+  version "0.0.52"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.52.tgz#7f1f57ad5b741f3d5b210d3b1f145640d89bf8fe"
+  integrity sha512-BZWrtCU0bMVAIliIV+HJO1f1PR41M7NKjfxrFJwwhKI1KwhwOxYw1SXg9ao+CIMt774nFuGiG6eU+udtbEI9oQ==
 
 "@types/graceful-fs@^4.1.2":
   version "4.1.3"
@@ -1674,7 +1674,7 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.1.1.tgz#345f0dffad5c735e7373d2fec9a1023e6a44b83e"
   integrity sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ==
 
-acorn@^7.1.1, acorn@^7.2.0:
+acorn@^7.1.1:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.2.0.tgz#17ea7e40d7c8640ff54a694c889c26f31704effe"
   integrity sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==
@@ -1688,6 +1688,11 @@ acorn@^8.2.4:
   version "8.4.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.4.0.tgz#af53266e698d7cffa416714b503066a82221be60"
   integrity sha512-ULr0LDaEqQrMFGyQ3bhJkLsbtrQ8QibAseGZeaSUiT/6zb9IvIkomWHJIvgvwad+hinRAgsI51JcWk2yvwyL+w==
+
+acorn@^8.7.1:
+  version "8.7.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.1.tgz#0197122c843d1bf6d0a5e83220a788f278f63c30"
+  integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
 
 agent-base@6:
   version "6.0.2"


### PR DESCRIPTION
The expression formula should be error-free in evaluation, nullish variable access should be optional chained instead of raising error.